### PR TITLE
Add '/' when loading chrome

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,9 @@
     <head>
         <meta charset="UTF-8">
         <title>Access Requests</title>
-        <esi:include src="@@env/chrome/snippets/head.html"/>
+        <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>
-        <esi:include src="@@env/chrome/snippets/body.html"/>
+        <esi:include src="/@@env/chrome/snippets/body.html"/>
     </body>
 </html>


### PR DESCRIPTION
Match e.g. https://github.com/RedHatInsights/user-preferences-frontend/blob/2c3f00106681abc608b5f91947b92a9f8a3d5473/src/index.html#L6

On fakamai it seems not having the '/' is no big deal. But on akamai it seems to not load chrome correctly. 

cc @Hyperkid123 @karelhala 