### PR TITLE
Use internal redux store

### DIFF
--- a/src/Routes/AccessRequestsPage.js
+++ b/src/Routes/AccessRequestsPage.js
@@ -1,25 +1,28 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { PageSection, Title } from '@patternfly/react-core';
 import AccessRequestsTable from '../Components/AccessRequestsTable';
 import PropTypes from 'prop-types';
+import registry from '../store';
+import ErroReducerCatcher from '../Components/ErrorReducerCatcher';
 
-const AccessRequestsPage = ({ getRegistry, isInternal }) => {
+const AccessRequestsPage = ({ isInternal }) => {
   return (
-    <Provider store={getRegistry().getStore()}>
-      <PageSection variant="light">
-        <Title headingLevel="h1" className="pf-u-pb-sm">
-          Access Requests
-        </Title>
-        <p>
-          Below is a list of all submitted requests for read only account
-          access.
-        </p>
-      </PageSection>
-      <PageSection padding={{ default: 'noPadding' }}>
-        <AccessRequestsTable isInternal={isInternal} />
-      </PageSection>
+    <Provider store={registry.getStore()}>
+      <ErroReducerCatcher>
+        <PageSection variant="light">
+          <Title headingLevel="h1" className="pf-u-pb-sm">
+            Access Requests
+          </Title>
+          <p>
+            Below is a list of all submitted requests for read only account
+            access.
+          </p>
+        </PageSection>
+        <PageSection padding={{ default: 'noPadding' }}>
+          <AccessRequestsTable isInternal={isInternal} />
+        </PageSection>
+      </ErroReducerCatcher>
     </Provider>
   );
 };
@@ -27,8 +30,7 @@ const AccessRequestsPage = ({ getRegistry, isInternal }) => {
 // This component is a federated module used in https://github.com/RedHatInsights/insights-rbac-ui
 // Try not to break RBAC.
 AccessRequestsPage.propTypes = {
-  getRegistry: PropTypes.func,
   isInternal: PropTypes.bool,
 };
 
-export default withRouter(AccessRequestsPage);
+export default AccessRequestsPage;


### PR DESCRIPTION
For some reason, the access request modules were using RBAC redux store, instead of using its own internal store. The access request never reads data from the RBAC store, so there is no reason to use it. In addition, using the RBAC store will cause issues in modules. They will not react to internal state updates but will expect RBAC to handle it.

Solves issues in https://issues.redhat.com/browse/RHCLOUD-17060