### PR TITLE
Use target_org access request query filtering.

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -4,8 +4,7 @@ module.exports = {
   appUrl: [
     '/internal/access-requests',
     '/settings/rbac/access-requests',
-    '/beta/internal/access-requests',
-    '/beta/settings/rbac/access-requests',
+    '/internal',
   ],
   debug: true,
   useProxy: true,

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -5,7 +5,8 @@ import registry, { RegistryContext } from './store';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers/helpers';
 
-const basename = getBaseName(window.location.pathname, 3);
+// the UI has to be accessible from both /internal and /internal/access-requests. The basename has to be /internal always
+const basename = getBaseName(window.location.pathname, 2);
 
 const AppEntry = () => (
   <RegistryContext.Provider

--- a/src/Components/AccessRequestsTable.js
+++ b/src/Components/AccessRequestsTable.js
@@ -148,7 +148,6 @@ const AccessRequestsTable = ({ isInternal }) => {
   const [accountFilter, setAccountFilter] = React.useState('');
   const [filtersDirty, setFiltersDirty] = React.useState(false);
   const hasFilters = statusSelections.length > 0 || accountFilter;
-  const orgIdEnabled = useFlag('platform.chrome.tamtool.orgid');
 
   // Row loading
   const [isLoading, setIsLoading] = React.useState(true);
@@ -163,10 +162,7 @@ const AccessRequestsTable = ({ isInternal }) => {
 
     isInternal
       ? listUrl.searchParams.append('query_by', 'user_id')
-      : listUrl.searchParams.append(
-          'query_by',
-          orgIdEnabled ? 'target_org' : 'target_account'
-        );
+      : listUrl.searchParams.append('query_by', 'target_org');
 
     listUrl.searchParams.append('offset', (page - 1) * perPage);
     listUrl.searchParams.append('limit', perPage);

--- a/src/Components/AccessRequestsTable.js
+++ b/src/Components/AccessRequestsTable.js
@@ -28,7 +28,6 @@ import {
   Th,
   Td,
 } from '@patternfly/react-table';
-import { useFlag } from '@unleash/proxy-client-react';
 import CancelRequestModal from './CancelRequestModal';
 import AccessRequestsWizard from './access-requests-wizard/AccessRequestsWizard';
 import { capitalize } from '@patternfly/react-core/dist/esm/helpers/util';

--- a/src/Components/mua-roles-table/MUARolesTable.js
+++ b/src/Components/mua-roles-table/MUARolesTable.js
@@ -308,7 +308,7 @@ const MUARolesTable = ({
           <Tr isExpanded={row.isExpanded}>
             {!isReadOnly && <Td />}
             <Td className="pf-u-p-0" colSpan={3}>
-              <TableComposable isCompact className="pf-m-no-border-rows">
+              <TableComposable className="pf-m-no-border-rows">
                 <Thead>
                   <Tr>
                     {expandedColumns.map((col) => (
@@ -351,12 +351,12 @@ const MUARolesTable = ({
           </Tr>
         </Tbody>
       ))}
-      {pagedRows.length === 0 && hasFilters && (
+      {pagedRows.length === 0 && hasFilters ? (
         <MUANoResults
           columns={columns}
           clearFiltersButton={clearFiltersButton}
         />
-      )}
+      ) : null}
     </TableComposable>
   );
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -48,20 +48,20 @@ export const Routes = () => {
         />
       )}
       <Switch>
-        <Route path="/" exact>
+        <Route path="/access-requests" exact>
           <AccessRequestsPage
             isInternal={isInternal}
             getRegistry={getRegistry}
           />
         </Route>
-        <Route path="/:requestId" exact>
+        <Route path="/access-requests/:requestId">
           <AccessRequestDetailsPage
             isInternal={isInternal}
             getRegistry={getRegistry}
           />
         </Route>
         <Route>
-          <Redirect to="/" />
+          <Redirect to="/access-requests" />
         </Route>
       </Switch>
     </Suspense>

--- a/src/Routes/AccessRequestDetailsPage.js
+++ b/src/Routes/AccessRequestDetailsPage.js
@@ -35,7 +35,7 @@ const BaseAccessRequestDetailsPage = ({ isInternal }) => {
     apiInstance
       .get(
         `${API_BASE}/cross-account-requests/${requestId}/${
-          isInternal ? '?query_by=user_id' : '?query_by=target_account'
+          isInternal ? '?query_by=user_id' : '?query_by=target_org'
         }`,
         { headers: { Accept: 'application/json' } }
       )
@@ -68,7 +68,7 @@ const BaseAccessRequestDetailsPage = ({ isInternal }) => {
 
   const requestDisplayProps = [
     ...(isInternal
-      ? ['request_id', 'target_account']
+      ? ['request_id', 'target_account', 'target_org']
       : ['first_name', 'last_name']),
     'start_date',
     'end_date',


### PR DESCRIPTION
Partially fixes: https://issues.redhat.com/browse/RHCLOUD-20901

It Fixes the following API error:
```
detail: "query_by query parameter value 'target_account' is invalid. ['target_org', 'user_id'] are valid inputs."
source: "detail"
status: "400"
```

Also fixes issues in prod when the app is rendered also at `/internal` which the router was not confitued to do.