### PR TITLE
fix: Make access-requests own /internal

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -27,9 +27,18 @@ objects:
         - id: internal-access
           module: "./RootApp"
           routes:
+          - pathname: "/internal"
           - pathname: "/internal/access-requests"
           - pathname: "/settings/rbac/access-requests"
           - pathname: "/iam/user-access/access-requests"
+      bundleSegments:
+        - segmentId: internal-access-requests
+          bundleId: internal
+          position: 100
+          navItems:
+            - id: accessRequests
+              title: Access Requests
+              href: /internal/access-requests
       navigationSegments:
         - segmentId: iam-access-requests
           navItems:
@@ -37,7 +46,6 @@ objects:
               title: Red Hat Access Requests
               href: /iam/user-access/access-requests
               notifier: chrome.accessRequests.hasUnseen
-        
 
 parameters:
   - name: ENV_NAME

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -67,6 +67,7 @@ export const Routing = ({ userData }: { userData: UserData }) => {
       )}
       <Routes>
         {renderedRoutes}
+        {/* Catch all unmatched routes */}
         <Route path="*" element={<MissingPage />} />
       </Routes>
     </Suspense>

--- a/src/Routing.tsx
+++ b/src/Routing.tsx
@@ -67,7 +67,6 @@ export const Routing = ({ userData }: { userData: UserData }) => {
       )}
       <Routes>
         {renderedRoutes}
-        {/* Catch all unmatched routes */}
         <Route path="*" element={<MissingPage />} />
       </Routes>
     </Suspense>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Navigating to the internal bundle on both stage and prod results in either a sentry error (on stage) or a "We lost that page" state (on prod). The left nav also appears empty.

From my investigation it seems that commit-tracker owned /internal was owned by commit-tracker which was archived last month. This change should fix the issues and make access-requests own /internal and redirect to /internal/access-requests, hopefully fixing the /internal page and left nav issues.

[RHCLOUD-50022](https://issues.redhat.com/browse/RHCLOUD-50022)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/018f4085-ce01-4b59-8466-20255c4100f3" />


#### After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2b3ea460-605b-48ef-93f8-2ec48b1b2a32" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-50022]: https://redhat.atlassian.net/browse/RHCLOUD-50022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ